### PR TITLE
Make only pages visible to display for each subject

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -43,12 +43,15 @@
 		return $subject_set;
 	}
 	
-	function get_pages_for_subject($subject_id) {
+	function get_pages_for_subject($subject_id, $public = true) {
 		global $connection;
 		$query = "SELECT * 
-				FROM pages 
-				WHERE subject_id = {$subject_id} 
-				ORDER BY position ASC";
+				FROM pages "; 
+		$query .= "WHERE subject_id = {$subject_id} ";
+		if ($public){
+			$query .= "AND visible = 1 ";
+		}
+		$query .= "ORDER BY position ASC";
 		$page_set = mysql_query($query, $connection);
 		confirm_query($page_set);
 		return $page_set;
@@ -111,7 +114,7 @@
 			if ($subject["id"] == $sel_subject['id']) { $output .= " class=\"selected\""; }
 			$output .= "><a href=\"edit_subject.php?subj=" . urlencode($subject["id"]) . 
 				"\">{$subject["menu_name"]}</a></li>";
-			$page_set = get_pages_for_subject($subject["id"]);
+			$page_set = get_pages_for_subject($subject["id"], $public);
 			$output .= "<ul class=\"pages\">";
 			while ($page = mysql_fetch_array($page_set)) {
 				$output .= "<li";
@@ -134,7 +137,7 @@
 			$output .= "><a href=\"index.php?subj=" . urlencode($subject["id"]) . 
 				"\">{$subject["menu_name"]}</a></li>";
 			if ($subject["id"] == $sel_subject['id']) {	
-				$page_set = get_pages_for_subject($subject["id"]);
+				$page_set = get_pages_for_subject($subject["id"], $public);
 				$output .= "<ul class=\"pages\">";
 				while ($page = mysql_fetch_array($page_set)) {
 					$output .= "<li";

--- a/page_form.php
+++ b/page_form.php
@@ -20,7 +20,7 @@
 	?>
 </select></p>
 <p>Visible: 
-	<input type="radio" name="visible" value="0"<?php 
+	<input type="radio" name="visible" value="2"<?php 
 	if ($sel_page['visible'] == 2) { echo " checked"; } 
 	?> /> No
 	&nbsp;


### PR DESCRIPTION
### What does this PR do?
- This pull request makes pages with that are visible to display for each subject in index.php 

### Description of task to be completed:
- I added the argument '$public=true' to the function -get_pages_for_subject()
- I I also added a condition that executes the query "AND visible = 1 " , when $public is true.
### Picture representation for the changes made:
![query](https://user-images.githubusercontent.com/48205576/55396993-1442f380-54fa-11e9-9211-525ab3ba8c87.PNG)
![Emosire is the only visible page under services](https://user-images.githubusercontent.com/48205576/55397001-16a54d80-54fa-11e9-9caf-2cbad103c5d5.PNG)
![page olere is set as noot visible under subject sevices](https://user-images.githubusercontent.com/48205576/55397012-1a38d480-54fa-11e9-8b72-080e379e7fd4.PNG)

